### PR TITLE
Segment PUSH endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ This is a work-in-progress hobby project which aims to create a basic race timer
 
 - [Architecture](docs/architecture.md)
 - [Environment setup for development](docs/dev-environment.md)
+- [ADRs](docs/adr) ([What is an ADR?](https://github.com/joelparkerhenderson/architecture_decision_record))

--- a/docs/adr/testing-only-happy-path.md
+++ b/docs/adr/testing-only-happy-path.md
@@ -1,0 +1,23 @@
+# Until further notice, for new code changes only the "happy path" must be tested
+
+## Status
+
+Accepted
+
+## Context
+
+Happy path tests are when we test the application behavior under normal circumstances:
+
+- Application is properly integrated with the database
+- Valid parameters are passed
+- The state of the application / database is as expected
+
+For a more robust application we should test the behavior eg. for invalid parameters.
+
+## Decision
+
+At this point we prefer development pace over robustness. So we will test only the "happy path".
+
+## Consequences
+
+Development will be faster, but the behavior of the application will be less predictable in error scenarios.

--- a/server/app.go
+++ b/server/app.go
@@ -33,10 +33,11 @@ func (a *App) Run(addr string) {
 	log.Fatal(http.ListenAndServe(addr, a.Router))
 }
 
-func (a *App) getTimeTable(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "Time table")
+func (a *App) initializeRoutes() {
+	a.Router.HandleFunc("/segments", a.createSegmentMiddleware).Methods("POST")
 }
 
-func (a *App) initializeRoutes() {
-	a.Router.HandleFunc("/results", a.getTimeTable).Methods("GET")
+func (a *App) createSegmentMiddleware(w http.ResponseWriter, r *http.Request) {
+	var segmentEndpoint SegmentEndpoint
+	segmentEndpoint.create(w, r, a.DB)
 }

--- a/server/core/segment.go
+++ b/server/core/segment.go
@@ -1,0 +1,25 @@
+package core
+
+import (
+	"database/sql"
+	"log"
+)
+
+// TODO: normally we shouldn't export members of this domain object.
+type Segment struct {
+	Id   int64  `json:"id"`
+	Name string `json:"name"`
+}
+
+func (s *Segment) Save(db *sql.DB) error {
+	err := db.QueryRow(
+		"INSERT INTO segments(name) VALUES($1) RETURNING id",
+		s.Name).Scan(&s.Id)
+
+	if err != nil {
+		log.Fatal("Could not save segment ", s, err)
+		return err
+	}
+
+	return nil
+}

--- a/server/go.mod
+++ b/server/go.mod
@@ -5,4 +5,5 @@ go 1.16
 require (
 	github.com/gorilla/mux v1.8.0
 	github.com/lib/pq v1.10.0 // indirect
+	github.com/stretchr/testify v1.7.0 // indirect
 )

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,4 +1,15 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/lib/pq v1.10.0 h1:Zx5DJFEYQXio93kgXnQ09fXNiUKsqv4OUEu2UtGcB1E=
 github.com/lib/pq v1.10.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/server/segments_endpoint.go
+++ b/server/segments_endpoint.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+
+	"github.com/dadikovi/race-timer/server/core"
+)
+
+type SegmentEndpoint struct{}
+
+func (se *SegmentEndpoint) create(w http.ResponseWriter, r *http.Request, db *sql.DB) {
+	var s core.Segment
+
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&s); err != nil {
+		respondWithError(w, http.StatusBadRequest, "Invalid request payload")
+		return
+	}
+	defer r.Body.Close()
+
+	if err := s.Save(db); err != nil {
+		respondWithError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	respondWithJSON(w, http.StatusCreated, s)
+}
+
+func respondWithError(w http.ResponseWriter, code int, message string) {
+	respondWithJSON(w, code, map[string]string{"error": message})
+}
+
+func respondWithJSON(w http.ResponseWriter, code int, payload interface{}) {
+	response, _ := json.Marshal(payload)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	w.Write(response)
+}

--- a/server/segments_endpoint_test.go
+++ b/server/segments_endpoint_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithValidData(t *testing.T) {
+	// given
+	clearTable()
+	segmentName := "some-new-segment"
+	var responseBody map[string]interface{}
+
+	req, _ := http.NewRequest("POST", "/segments", bytes.NewBufferString(`{"name": "`+segmentName+`"}"`))
+
+	// when we call the endpoint
+	response := executeRequest(req)
+	json.Unmarshal([]byte(response.Body.String()), &responseBody)
+
+	// then it returns the newly created element
+	assert.Equal(t, response.Code, http.StatusOK, "Response code should be 200/OK")
+	assert.NotNil(t, responseBody)
+	assert.Equal(t, responseBody["name"], segmentName, "Should return the given segment name")
+	assert.Equal(t, responseBody["id"], 1)
+
+	// when we get all the segments from the database
+	segmentsFromDatabase := getSegments()
+
+	// then there will be only our newly created element in it
+	assert.Equal(t, len(segmentsFromDatabase), 1, "One record should be in the database")
+	assert.Equal(t, segmentsFromDatabase[0]["name"], segmentName)
+	assert.Equal(t, segmentsFromDatabase[0]["id"], 1)
+}
+
+func executeRequest(req *http.Request) *httptest.ResponseRecorder {
+	rr := httptest.NewRecorder()
+	a.Router.ServeHTTP(rr, req)
+
+	return rr
+}
+
+type M map[string]interface{}
+
+func getSegments() []M {
+	rows, _ := a.DB.Query("SELECT * FROM segments")
+	defer rows.Close()
+	var result []M
+
+	for rows.Next() {
+		var (
+			id   int64
+			name string
+		)
+		rows.Scan(&id, &name)
+
+		var row M
+		row["name"] = name
+		row["id"] = id
+		result = append(result, row)
+	}
+
+	return result
+}


### PR DESCRIPTION
## Description

The `Create segment` endpoint will be used by the admin client.
Expect some documentation in the future about what a segment is :D


## Technical details

- For now we will test as little as required for making the development easier. I wrote an ADR about this decision.
- The architecture diagram shows two layer, the `Server Application` and the `Core`. The former will be represented by the `main` package, the latter by `core` package.
- For now the `Segment` domain object exposes each of its fields, which is not so great. I should change this in the future.

Fixes gh-1
