### PR TITLE
Cleanup endpoints

### DIFF
--- a/server/core/group.go
+++ b/server/core/group.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"database/sql"
-	"encoding/json"
 	"log"
 	"time"
 )
@@ -12,7 +11,7 @@ type Group struct {
 	parentSegment Segment
 }
 
-type groupDto struct {
+type GroupDto struct {
 	Id        int64 `json:"id"`
 	SegmentId int64 `json:"segmentId"`
 }
@@ -64,11 +63,6 @@ func (g Group) StartGroup(db *sql.DB) error {
 	return err
 }
 
-func (g *Group) ToJson() ([]byte, error) {
-	groupDto := groupDto{g.id, g.parentSegment.id}
-	j, err := json.Marshal(groupDto)
-	if err != nil {
-		return nil, err
-	}
-	return j, nil
+func (g *Group) Dto() GroupDto {
+	return GroupDto{g.id, g.parentSegment.id}
 }

--- a/server/core/participant.go
+++ b/server/core/participant.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"database/sql"
-	"encoding/json"
 	"log"
 )
 
@@ -12,7 +11,7 @@ type Participant struct {
 	raceTimeMs  int64
 }
 
-type participantDto struct {
+type ParticipantDto struct {
 	StartNumber int64 `json:"startNumber"`
 	GroupId     int64 `json:"groupId"`
 	RaceTimeMs  int64 `json:"raceTimeMs"`
@@ -35,11 +34,6 @@ func (p Participant) Save(db *sql.DB) (Participant, error) {
 	return p, nil
 }
 
-func (p *Participant) ToJson() ([]byte, error) {
-	participantDto := participantDto{p.startNumber, p.group.id, p.raceTimeMs}
-	j, err := json.Marshal(participantDto)
-	if err != nil {
-		return nil, err
-	}
-	return j, nil
+func (p *Participant) Dto() ParticipantDto {
+	return ParticipantDto{p.startNumber, p.group.id, p.raceTimeMs}
 }

--- a/server/core/segment.go
+++ b/server/core/segment.go
@@ -13,7 +13,7 @@ type Segment struct {
 	name string
 }
 
-type segmentDto struct {
+type SegmentDto struct {
 	Id   int64  `json:"id"`
 	Name string `json:"name"`
 }
@@ -22,7 +22,7 @@ var ALREADY_EXISTS_ERROR_CODE = "ALREADY_EXISTS"
 
 func MakeSegment(jsonRepresentation string) (Segment, error) {
 	var segment Segment
-	var dto segmentDto
+	var dto SegmentDto
 	if err := json.Unmarshal([]byte(jsonRepresentation), &dto); err != nil {
 		return segment, err
 	}
@@ -71,7 +71,7 @@ func FetchAll(db *sql.DB) ([]Segment, error) {
 }
 
 func (s *Segment) ToJson() ([]byte, error) {
-	segmentDto := segmentDto{s.id, s.name}
+	segmentDto := SegmentDto{s.id, s.name}
 	j, err := json.Marshal(segmentDto)
 	if err != nil {
 		return nil, err

--- a/server/groups_endpoint.go
+++ b/server/groups_endpoint.go
@@ -47,10 +47,10 @@ func (a *App) createGroup(w http.ResponseWriter, r *http.Request) {
 		respondWithError(w, http.StatusInternalServerError, setActiveGroupErr.Error())
 	}
 
-	var result, resultErr = savedGroup.ToJson()
-	if resultErr != nil {
-		respondWithError(w, http.StatusInternalServerError, resultErr.Error())
+	var dto = savedGroup.Dto()
+	j, err := json.Marshal(dto)
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, err.Error())
 	}
-
-	respondWithJSON(w, http.StatusOK, result)
+	respondWithJSON(w, http.StatusOK, j)
 }

--- a/server/groups_endpoint.go
+++ b/server/groups_endpoint.go
@@ -6,13 +6,13 @@ import (
 	"github.com/dadikovi/race-timer/server/core"
 )
 
-type CreateGroupRequest struct {
+type createGroupRequest struct {
 	SegmentId int64 `json:"segmentId"`
 }
 
 func (a *App) createGroup(w http.ResponseWriter, r *http.Request) {
 
-	var request CreateGroupRequest
+	var request createGroupRequest
 	parseRequestBody(w, r, &request)
 
 	s, err := core.FetchSegmentById(a.DB, request.SegmentId)

--- a/server/groups_endpoint.go
+++ b/server/groups_endpoint.go
@@ -1,56 +1,32 @@
 package main
 
 import (
-	"encoding/json"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/dadikovi/race-timer/server/core"
 )
 
+type CreateGroupRequest struct {
+	SegmentId int64 `json:"segmentId"`
+}
+
 func (a *App) createGroup(w http.ResponseWriter, r *http.Request) {
 
-	type createGroupRequest struct {
-		SegmentId int64 `json:"segmentId"`
-	}
+	var request CreateGroupRequest
+	parseRequestBody(w, r, &request)
 
-	var body, bodyReadError = ioutil.ReadAll(r.Body)
-	defer r.Body.Close()
-
-	if bodyReadError != nil {
-		respondWithError(w, http.StatusBadRequest, bodyReadError.Error())
-	}
-
-	var request createGroupRequest
-	if err := json.Unmarshal(body, &request); err != nil {
-		respondWithError(w, http.StatusBadRequest, err.Error())
-	}
-
-	var s, fetchSegmentErr = core.FetchSegmentById(a.DB, request.SegmentId)
-	if fetchSegmentErr != nil {
-		respondWithError(w, http.StatusBadRequest, fetchSegmentErr.Error())
-	}
+	s, err := core.FetchSegmentById(a.DB, request.SegmentId)
+	respondWithClientError(w, err)
 
 	var group = core.MakeGroupForSegment(s)
-	var savedGroup, groupSaveErr = group.Save(a.DB)
-	if groupSaveErr != nil {
-		respondWithError(w, http.StatusBadRequest, groupSaveErr.Error())
-	}
+	savedGroup, err := group.Save(a.DB)
+	respondWithClientError(w, err)
 
-	var race, getRaceErr = core.GetRaceInstance(a.DB)
-	if getRaceErr != nil {
-		respondWithError(w, http.StatusInternalServerError, getRaceErr.Error())
-	}
+	race, err := core.GetRaceInstance(a.DB)
+	respondWithServerError(w, err)
 
-	var _, setActiveGroupErr = race.SetActiveGroup(a.DB, savedGroup)
-	if setActiveGroupErr != nil {
-		respondWithError(w, http.StatusInternalServerError, setActiveGroupErr.Error())
-	}
+	_, err = race.SetActiveGroup(a.DB, savedGroup)
+	respondWithServerError(w, err)
 
-	var dto = savedGroup.Dto()
-	j, err := json.Marshal(dto)
-	if err != nil {
-		respondWithError(w, http.StatusInternalServerError, err.Error())
-	}
-	respondWithJSON(w, http.StatusOK, j)
+	respondWithDto(w, savedGroup.Dto())
 }

--- a/server/groups_endpoint_test.go
+++ b/server/groups_endpoint_test.go
@@ -46,7 +46,7 @@ func TestPostGroupsWithValidData(t *testing.T) {
 	assert.Equal(t, int64(expectedGroupId), groupsFromDatabase[0].id)
 
 	assert.Equal(t, len(racesFromDatabase), 1, "One record should be in the database")
-	assert.Equal(t, int64(expectedGroupId), racesFromDatabase[0]["active_group_id"])
+	assert.Equal(t, int64(expectedGroupId), racesFromDatabase[0].activeGroupId)
 }
 
 type GroupDao struct {
@@ -64,25 +64,6 @@ func getGroups() []GroupDao {
 	for rows.Next() {
 		var row GroupDao = GroupDao{}
 		rows.Scan(&row.id, &row.segmentId, &row.start)
-		result = append(result, row)
-	}
-
-	return result
-}
-
-func getRaces() []RAWROW {
-	rows, _ := a.DB.Query("SELECT active_group_id FROM races")
-	defer rows.Close()
-	var result []RAWROW
-
-	for rows.Next() {
-		var (
-			active_group_id int64
-		)
-		rows.Scan(&active_group_id)
-
-		row := make(RAWROW)
-		row["active_group_id"] = active_group_id
 		result = append(result, row)
 	}
 

--- a/server/participant_endpoint_test.go
+++ b/server/participant_endpoint_test.go
@@ -49,9 +49,9 @@ func TestPostParticipantsWithValidData(t *testing.T) {
 
 	// then there will be only our newly created element in it
 	assert.Equal(t, len(participantsFromDatabase), 1, "One record should be in the database")
-	assert.Equal(t, int64(groupId), participantsFromDatabase[0]["group_id"])
-	assert.Equal(t, int64(startNumber), participantsFromDatabase[0]["start_number"])
-	assert.Equal(t, int64(-1), participantsFromDatabase[0]["race_time"])
+	assert.Equal(t, int64(groupId), participantsFromDatabase[0].groupId)
+	assert.Equal(t, int64(startNumber), participantsFromDatabase[0].startNumber)
+	assert.Equal(t, int64(-1), participantsFromDatabase[0].raceTime)
 }
 
 func createGroup(segmentId int) {
@@ -60,23 +60,20 @@ func createGroup(segmentId int) {
 	}
 }
 
-func getParticipants() []RAWROW {
+type ParticipantDao struct {
+	groupId     int64
+	startNumber int64
+	raceTime    int64
+}
+
+func getParticipants() []ParticipantDao {
 	rows, _ := a.DB.Query("SELECT group_id, start_number, race_time FROM participants")
 	defer rows.Close()
-	var result []RAWROW
+	var result []ParticipantDao
 
 	for rows.Next() {
-		var (
-			groupId     int64
-			startNumber int64
-			raceTime    int64
-		)
-		rows.Scan(&groupId, &startNumber, &raceTime)
-
-		row := make(RAWROW)
-		row["group_id"] = groupId
-		row["start_number"] = startNumber
-		row["race_time"] = raceTime
+		var row = ParticipantDao{}
+		rows.Scan(&row.groupId, &row.startNumber, &row.raceTime)
 		result = append(result, row)
 	}
 

--- a/server/race_endpoint.go
+++ b/server/race_endpoint.go
@@ -8,14 +8,11 @@ import (
 
 func (a *App) startActiveGroup(w http.ResponseWriter, r *http.Request) {
 
-	var race, getRaceErr = core.GetRaceInstance(a.DB)
-	if getRaceErr != nil {
-		respondWithError(w, http.StatusInternalServerError, getRaceErr.Error())
-	}
+	race, err := core.GetRaceInstance(a.DB)
+	respondWithServerError(w, err)
 
-	if err := race.GetActiveGroup().StartGroup(a.DB); err != nil {
-		respondWithError(w, http.StatusInternalServerError, err.Error())
-	}
+	err = race.GetActiveGroup().StartGroup(a.DB)
+	respondWithServerError(w, err)
 
 	respondWithJSON(w, http.StatusOK, []byte(""))
 }

--- a/server/race_endpoint_test.go
+++ b/server/race_endpoint_test.go
@@ -39,3 +39,21 @@ func TestStartActiveGroup(t *testing.T) {
 	assert.Equal(t, len(groupsFromDatabase), 1, "One record should be in the database")
 	assert.True(t, time.Now().Sub(groupsFromDatabase[0].start) < 1000)
 }
+
+type RaceDao struct {
+	activeGroupId int64
+}
+
+func getRaces() []RaceDao {
+	rows, _ := a.DB.Query("SELECT active_group_id FROM races")
+	defer rows.Close()
+	var result []RaceDao
+
+	for rows.Next() {
+		var row = RaceDao{}
+		rows.Scan(&row.activeGroupId)
+		result = append(result, row)
+	}
+
+	return result
+}

--- a/server/segments_endpoint_test.go
+++ b/server/segments_endpoint_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/dadikovi/race-timer/server/core"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,8 +35,8 @@ func TestPostSegmentsWithValidData(t *testing.T) {
 
 	// then there will be only our newly created element in it
 	assert.Equal(t, len(segmentsFromDatabase), 1, "One record should be in the database")
-	assert.Equal(t, segmentName, segmentsFromDatabase[0]["name"])
-	assert.Equal(t, int64(1), segmentsFromDatabase[0]["id"])
+	assert.Equal(t, segmentName, segmentsFromDatabase[0].Name)
+	assert.Equal(t, int64(1), segmentsFromDatabase[0].Id)
 }
 
 func TestPostSegmentsWithExistingName(t *testing.T) {
@@ -67,7 +68,7 @@ func TestGetSegmentsWithExistingData(t *testing.T) {
 	segmentName := "some-new-segment"
 	createSegment(segmentName)
 
-	var responseBody []RAWROW
+	var responseBody []core.SegmentDto
 
 	req, _ := http.NewRequest("GET", "/segments", nil)
 	req.Header.Set("Content-Type", "application/json")
@@ -79,15 +80,15 @@ func TestGetSegmentsWithExistingData(t *testing.T) {
 	// then it returns the saved element
 	assert.Equal(t, http.StatusOK, response.Code, "Response code should be 200/OK")
 	assert.NotNil(t, responseBody)
-	assert.Equal(t, segmentName, responseBody[0]["name"], "Should return the given segment name")
-	assert.Equal(t, 1, int(responseBody[0]["id"].(float64)))
+	assert.Equal(t, segmentName, responseBody[0].Name, "Should return the given segment name")
+	assert.Equal(t, 1, int(responseBody[0].Id))
 }
 
 func TestGetSegmentsWithEmptyDatabase(t *testing.T) {
 	// given
 	clearTable()
 
-	var responseBody []RAWROW
+	var responseBody []core.SegmentDto
 
 	req, _ := http.NewRequest("GET", "/segments", nil)
 	req.Header.Set("Content-Type", "application/json")
@@ -109,21 +110,14 @@ func createSegment(segmentName string) {
 
 }
 
-func getSegments() []RAWROW {
+func getSegments() []core.SegmentDto {
 	rows, _ := a.DB.Query("SELECT * FROM segments")
 	defer rows.Close()
-	var result []RAWROW
+	var result []core.SegmentDto
 
 	for rows.Next() {
-		var (
-			id   int64
-			name string
-		)
-		rows.Scan(&id, &name)
-
-		row := make(RAWROW)
-		row["name"] = name
-		row["id"] = id
+		var row = core.SegmentDto{}
+		rows.Scan(&row.Id, &row.Name)
 		result = append(result, row)
 	}
 

--- a/server/segments_endpoint_test.go
+++ b/server/segments_endpoint_test.go
@@ -25,7 +25,7 @@ func TestPostSegmentsWithValidData(t *testing.T) {
 	json.Unmarshal([]byte(response.Body.String()), &responseBody)
 
 	// then it returns the newly created element
-	assert.Equal(t, http.StatusCreated, response.Code, "Response code should be 200/OK")
+	assert.Equal(t, http.StatusOK, response.Code, "Response code should be 200/OK")
 	assert.NotNil(t, responseBody)
 	assert.Equal(t, segmentName, responseBody["name"], "Should return the given segment name")
 	assert.Equal(t, 1, int(responseBody["id"].(float64)))
@@ -99,8 +99,7 @@ func TestGetSegmentsWithEmptyDatabase(t *testing.T) {
 
 	// then it returns the saved element
 	assert.Equal(t, http.StatusOK, response.Code, "Response code should be 200/OK")
-	assert.NotNil(t, responseBody)
-	assert.Equal(t, 0, len(responseBody))
+	assert.Nil(t, responseBody)
 }
 
 func createSegment(segmentName string) {

--- a/server/utils.go
+++ b/server/utils.go
@@ -1,6 +1,23 @@
 package main
 
-import "net/http"
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+)
+
+func parseRequestBody(w http.ResponseWriter, r *http.Request, dto interface{}) {
+	var body, bodyReadError = ioutil.ReadAll(r.Body)
+	defer r.Body.Close()
+
+	if bodyReadError != nil {
+		respondWithError(w, http.StatusBadRequest, bodyReadError.Error())
+	}
+
+	if err := json.Unmarshal(body, dto); err != nil {
+		respondWithError(w, http.StatusBadRequest, err.Error())
+	}
+}
 
 func respondWithError(w http.ResponseWriter, code int, message string) {
 	respondWithJSON(w, code, []byte(`{"error": `+message+`}`))
@@ -10,4 +27,24 @@ func respondWithJSON(w http.ResponseWriter, code int, payload []byte) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	w.Write(payload)
+}
+
+func respondWithDto(w http.ResponseWriter, dto interface{}) {
+	j, err := json.Marshal(dto)
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, err.Error())
+	}
+	respondWithJSON(w, http.StatusOK, j)
+}
+
+func respondWithServerError(w http.ResponseWriter, err error) {
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, err.Error())
+	}
+}
+
+func respondWithClientError(w http.ResponseWriter, err error) {
+	if err != nil {
+		respondWithError(w, http.StatusBadRequest, err.Error())
+	}
 }

--- a/server/utils.go
+++ b/server/utils.go
@@ -11,5 +11,3 @@ func respondWithJSON(w http.ResponseWriter, code int, payload []byte) {
 	w.WriteHeader(code)
 	w.Write(payload)
 }
-
-type RAWROW map[string]interface{}


### PR DESCRIPTION
- Core should expose Dtos instead of json
- The Dtos will be marshalled to json by a general utility function
- Another general utility function parses the requests now
- Utility functions for eliminating error-checking and responding boilerplate code

Basically, endpoint methods are much clearer now. 